### PR TITLE
Popsift squash addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ before_script:
        -DCeres_DIR="${DEPS_INSTALL_PATH}/share/Ceres" \
        -DEIGEN_INCLUDE_DIR_HINTS="${DEPS_INSTALL_PATH}" \
        -DOpenMVG_USE_CCTAG=OFF \
-       -DPOPSIFT_ROOT=$POPSIFT_INSTALL \
+       -DPopSift_DIR="${DEPS_INSTALL_PATH}/share/PopSift" \
        . $OPENMVG_SOURCE
   # Build for code coverage evaluation
   #- cmake -DOpenMVG_BUILD_COVERAGE=ON -DOpenMVG_BUILD_TESTS=ON -DOpenMVG_BUILD_EXAMPLES=ON . ../openMVG/src

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,8 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 PROJECT(openMVG C CXX)
 
+cmake_policy( SET CMP0028 NEW ) # :: in target list means imported target
+
 # guard against in-source builds
 IF(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "In-source builds not allowed.")
@@ -471,6 +473,7 @@ ADD_SUBDIRECTORY(third_party)
 # CCTag
 # ==============================================================================
 IF(OpenMVG_USE_CCTAG)
+  SET(CUDA_SEPARABLE_COMPILATION ON)
   FIND_PACKAGE(CCTag 1.0.0 CONFIG)
   IF(NOT CCTag_FOUND)
     MESSAGE(STATUS "CCTAG package not found, CCTAG will be disabled")
@@ -523,11 +526,11 @@ SET(OpenMVG_INCLUDE_DIRS
 
 INCLUDE_DIRECTORIES(${OpenMVG_INCLUDE_DIRS})
 
-find_package(Popsift)
-if(POPSIFT_FOUND)
+find_package(PopSift)
+if(PopSift_FOUND)
   ADD_DEFINITIONS(-DHAVE_POPSIFT)
-  INCLUDE_DIRECTORIES(${POPSIFT_INCLUDE_DIR})
-  LINK_DIRECTORIES(${POPSIFT_LIBRARY_DIR})
+  INCLUDE_DIRECTORIES(${PopSift_INCLUDE_DIR})
+  LINK_DIRECTORIES(${PopSift_LIBRARY_DIR})
 endif()
 
 find_package(CUDA 7.0) #use CUDA 7.0 because of nvcc bug with CUB

--- a/src/nonFree/sift/SIFT_popSIFT_describer.hpp
+++ b/src/nonFree/sift/SIFT_popSIFT_describer.hpp
@@ -25,10 +25,10 @@ namespace features {
 class SIFT_popSIFT_describer : public Image_describer
 {
 public:
-  SIFT_popSIFT_describer(const SiftParams & params = SiftParams(), bool bOrientation = true)
+  SIFT_popSIFT_describer(const SiftParams & params = SiftParams(), bool bOrientationDummy = true )
     : Image_describer()
     , _params(params)
-    , _bOrientation(bOrientation)
+    /* , _bOrientation(bOrientation) */
     , _previousImageSize(0, 0)
   {
     std::cout << "SIFT_popSIFT_describer" << std::endl;
@@ -160,12 +160,12 @@ public:
   {
     ar(
      cereal::make_nvp("params", _params),
-     cereal::make_nvp("bOrientation", _bOrientation));
+     cereal::make_nvp("bOrientation", true ));
   }
 
 private:
   SiftParams _params;
-  bool _bOrientation;
+  /* bool _bOrientation; */
 
   std::unique_ptr<PopSift> _popSift;
   std::pair<std::size_t, std::size_t> _previousImageSize;

--- a/src/openMVG_Samples/features_repeatability/CMakeLists.txt
+++ b/src/openMVG_Samples/features_repeatability/CMakeLists.txt
@@ -6,7 +6,7 @@ target_link_libraries(openMVG_sample_main_repeatability_dataset
   openMVG_system
   openMVG_multiview
   vlsift
-  ${POPSIFT_LIBRARIES}
+  PopSift::popsift # ${POPSIFT_LIBRARIES}
   stlplus
   ${CUDA_LIBRARIES}
   ${CUDA_CUDADEVRT_LIBRARY}

--- a/src/openMVG_Samples/siftPutativeMatches/CMakeLists.txt
+++ b/src/openMVG_Samples/siftPutativeMatches/CMakeLists.txt
@@ -1,3 +1,4 @@
+find_package(PopSift)
 
 ADD_DEFINITIONS(-DTHIS_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
@@ -7,6 +8,9 @@ TARGET_LINK_LIBRARIES(openMVG_sample_siftPutative
   openMVG_features
   openMVG_matching
   vlsift
-  stlplus)
+  PopSift::popsift
+  ${OpenCV_LIBS}
+  stlplus
+  )
 
 SET_PROPERTY(TARGET openMVG_sample_siftPutative PROPERTY FOLDER OpenMVG/Samples)

--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -43,9 +43,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_ComputeFeatures
   easyexif
   stlplus
   vlsift
-  ${POPSIFT_LIBRARIES}
-  ${CUDA_LIBRARIES}
-  ${CUDA_CUDADEVRT_LIBRARY}
+  PopSift::popsift # ${POPSIFT_LIBRARIES}
   )
 
 IF(OpenMVG_USE_CCTAG)
@@ -143,7 +141,7 @@ TARGET_LINK_LIBRARIES(openMVG_main_ComputeCCTagStructureFromKnownPoses
   )
 SET_PROPERTY(TARGET openMVG_main_ComputeCCTagStructureFromKnownPoses PROPERTY FOLDER OpenMVG/software)
 INSTALL(TARGETS openMVG_main_ComputeCCTagStructureFromKnownPoses DESTINATION bin/)
-ENDIF()
+ENDIF(OpenMVG_USE_CCTAG)
 
 ADD_EXECUTABLE(openMVG_main_ComputeSfM_DataColor main_ComputeSfM_DataColor.cpp)
 TARGET_LINK_LIBRARIES(openMVG_main_ComputeSfM_DataColor

--- a/src/software/SfM/main_ComputeFeatures.cpp
+++ b/src/software/SfM/main_ComputeFeatures.cpp
@@ -263,7 +263,7 @@ int main(int argc, char **argv)
     << "   SIFT (default),\n"
     << "   SIFT_FLOAT to use SIFT stored as float,\n"
 #ifdef HAVE_POPSIFT
-    << "   POPSIFT: SIFT with GPU implementation,\n"
+    << "   POPSIFT: POPART SIFT with GPU implementation,\n"
 #endif
     << "   AKAZE_FLOAT: AKAZE with floating point descriptors,\n"
     << "   AKAZE_MLDB:  AKAZE with binary descriptors\n"


### PR DESCRIPTION
(1) popart_squash_addon uses PopSift::popsift in target_link_libraries and changes various names to CamelCase. The all Uppercase version of branch popart_squash is not detected in find_package with my cmake 3.4.
(2) Separable compilation is apparently needed to have PopSift and CCTag linking at the same time (I had double linkage without this).

Note that the .travis.yml change is guesswork.
