### PR TITLE
Bugfix for race condition leading to infinite loop.

### DIFF
--- a/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
+++ b/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
@@ -389,7 +389,8 @@ bool SequentialSfMReconstructionEngine::ChooseInitialPair(Pair & initialPairInde
 
     if (_sfm_data.GetIntrinsics().empty() || valid_views.empty())
     {
-      std::cerr << "There is no defined intrinsic data in order to compute an essential matrix for the initial pair.";
+
+      OPENMVG_CERR("There is no defined intrinsic data in order to compute an essential matrix for the initial pair.");
       return false;
     }
 

--- a/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
+++ b/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
@@ -178,7 +178,7 @@ void SequentialSfMReconstructionEngine::RobustResectionOfImages(
   while (FindNextImagesGroupForResection(vec_possible_resection_indexes, set_remainingViewId))
   {
     auto chrono_start = std::chrono::steady_clock::now();
-    OPENMVG_LOG_DEBUG("Resection group start " << resectionGroupIndex << " with " << vec_possible_resection_indexes.size() << " images.\n";
+    OPENMVG_LOG_DEBUG("Resection group start " << resectionGroupIndex << " with " << vec_possible_resection_indexes.size() << " images.\n");
     bool bImageAdded = false;
     // Add images to the 3D reconstruction
     for (const size_t possible_resection_index: vec_possible_resection_indexes )
@@ -389,9 +389,7 @@ bool SequentialSfMReconstructionEngine::ChooseInitialPair(Pair & initialPairInde
 
     if (_sfm_data.GetIntrinsics().empty() || valid_views.empty())
     {
-      std::cerr
-        << "There is no defined intrinsic data in order to compute an essential matrix for the initial pair."
-       );
+      std::cerr << "There is no defined intrinsic data in order to compute an essential matrix for the initial pair.";
       return false;
     }
 

--- a/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
+++ b/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
@@ -1416,7 +1416,12 @@ bool SequentialSfMReconstructionEngine::Resection(const std::size_t viewIndex)
         const Vec2 xJ = _features_provider->feats_per_view.at(J)[track.at(J)].coords().cast<double>();
 
         // test if the track already exists in 3D
-        if (_sfm_data.structure.count(trackId) != 0)
+        bool trackIdExists;
+#pragma omp critical
+        {
+            trackIdExists = _sfm_data.structure.find(trackId) != _sfm_data.structure.end();
+        }
+        if (trackIdExists)
         {
           // 3D point triangulated before, only add image observation if needed
 #ifdef OPENMVG_USE_OPENMP


### PR DESCRIPTION
Even though .count() (more efficient version here) does not modify the
data-structure, other threads running in parallel might be doing so.
When traversal encounters a data structure which is in process of being
modified, .count() called std::distance on pair of iterators returned by
equal_range where first > second.  Thus, infinite loop in distance.