### PR TITLE
[ci] set num threads for omp when testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ script:
 # limit GCC builds to a reduced number of thread for the virtual machine
   - make -j 2 VERBOSE=1
 # Perform unit tests only on GCC builds
+  - export OMP_NUM_THREADS=4
   - if [ "$CC" = "gcc" ]; then make test; fi
 # Perform benchmark through ground truth tests with many scenes
   - >


### PR DESCRIPTION
When executing the tests, the ones using openmp take a lot of time because travis tries to use all the threads on the physical machine but only few of them (eg 4) are available on the VM for the job.
See here https://docs.travis-ci.com/user/languages/cpp/#OpenMP-projects

Fixing num threads to a reasonable value, dramatically improves the test performances, eg
without the fix https://travis-ci.org/alicevision/openMVG/builds/231209785#L4100
Total Test time (real) = 657.67 sec

with the fix https://travis-ci.org/alicevision/openMVG/builds/232087029#L4107
Total Test time (real) =  15.58 sec