### PR TITLE
bugfix: compilation failed because of a bad 'auto' management.

### DIFF
--- a/src/openMVG/localization/VoctreeLocalizer.cpp
+++ b/src/openMVG/localization/VoctreeLocalizer.cpp
@@ -1457,7 +1457,7 @@ bool VoctreeLocalizer::localizeRig_opengv(const std::vector<features::MapRegions
       else
         residuals = currCamera.residuals(geometry::Pose3()*rigPose, vec_pts3D[camID], vec_pts2D[camID]);
 
-      auto sqrErrors = (residuals.cwiseProduct(residuals)).colwise().sum();
+      const Vec sqrErrors = (residuals.cwiseProduct(residuals)).colwise().sum();
 
 //      OPENMVG_LOG_DEBUG("Camera " << camID << " all reprojection errors after BA:");
 //      OPENMVG_LOG_DEBUG(sqrErrors);


### PR DESCRIPTION
During the compilation, this error occured:

`[ 96%] Building CXX object openMVG/localization/CMakeFiles/openMVG_localization.dir/VoctreeLocalizer.cpp.o
In file included from /usr/include/eigen3/Eigen/Core:297:0,
                 from /home/cdebize/Softwares/AliceVision/openMVG/src/openMVG/types.hpp:12,
                 from /home/cdebize/Softwares/AliceVision/openMVG/src/openMVG/localization/reconstructed_regions.hpp:11,
                 from /home/cdebize/Softwares/AliceVision/openMVG/src/openMVG/localization/VoctreeLocalizer.hpp:10,
                 from /home/cdebize/Softwares/AliceVision/openMVG/src/openMVG/localization/VoctreeLocalizer.cpp:1:
/usr/include/eigen3/Eigen/src/Core/DenseCoeffsBase.h: In instantiation of ‘Eigen::DenseCoeffsBase<Derived, 0>::CoeffReturnType Eigen::DenseCoeffsBase<Derived, 0>::coeff(Eigen::Index) const [with Derived = Eigen::PartialReduxExpr<const Eigen::CwiseBinaryOp<Eigen::internal::scalar_product_op<double, double>, const Eigen::Matrix<double, 2, -1>, const Eigen::Matrix<double, 2, -1> >, Eigen::internal::member_sum<double>, 0>; Eigen::DenseCoeffsBase<Derived, 0>::CoeffReturnType = double; Eigen::Index = long int]’:
/usr/include/eigen3/Eigen/src/Core/DenseCoeffsBase.h:181:19:   required from ‘Eigen::DenseCoeffsBase<Derived, 0>::CoeffReturnType Eigen::DenseCoeffsBase<Derived, 0>::operator()(Eigen::Index) const [with Derived = Eigen::PartialReduxExpr<const Eigen::CwiseBinaryOp<Eigen::internal::scalar_product_op<double, double>, const Eigen::Matrix<double, 2, -1>, const Eigen::Matrix<double, 2, -1> >, Eigen::internal::member_sum<double>, 0>; Eigen::DenseCoeffsBase<Derived, 0>::CoeffReturnType = double; Eigen::Index = long int]’
/home/cdebize/Softwares/AliceVision/openMVG/src/openMVG/localization/VoctreeLocalizer.cpp:1472:43:   required from here
/usr/include/eigen3/Eigen/src/Core/util/StaticAssert.h:32:40: error: static assertion failed: THIS_COEFFICIENT_ACCESSOR_TAKING_ONE_ACCESS_IS_ONLY_FOR_EXPRESSIONS_ALLOWING_LINEAR_ACCESS
     #define EIGEN_STATIC_ASSERT(X,MSG) static_assert(X,#MSG);
                                        ^
/usr/include/eigen3/Eigen/src/Core/DenseCoeffsBase.h:141:7: note: in expansion of macro ‘EIGEN_STATIC_ASSERT’
       EIGEN_STATIC_ASSERT(internal::evaluator<Derived>::Flags & LinearAccessBit,
       ^
openMVG/localization/CMakeFiles/openMVG_localization.dir/build.make:86: recipe for target 'openMVG/localization/CMakeFiles/openMVG_localization.dir/VoctreeLocalizer.cpp.o' failed
` 

To trade **auto** for **const Vec** solves the compilation error.